### PR TITLE
V0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "twitter-stream-bot-detection"
-version = "0.1.0"
+version = "0.1.1"
 description = "An application to watch the Twitter stream and send accounts to the [Botometer API](https://botometer.osome.iu.edu/) for analysis. The results are stored in a SQLite database."
 authors = ["dbrennand <52419383+dbrennand@users.noreply.github.com>"]
 license = "MIT"

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -73,14 +73,17 @@ class CustomStreamListener(tweepy.StreamListener):
             f"Tweet received. Sending Twitter user: {status.user.screen_name} to Botometer for analysis."
         )
         # Query the Botometer API for the Twitter user's bot-like scores
-        result = self.bom.check_account(status.user.id)
-        logging.info("Storing results in database.")
-        # Store the Twitter user's screen name, JSON response of the Tweet and Botometer API results
-        self.cur.execute(
-            "INSERT INTO data values (?, ?, ?)",
-            [status.user.screen_name, json.dumps(status._json), json.dumps(result)],
-        )
-        self.con.commit()
+        try:
+            result = self.bom.check_account(status.user.id)
+            logging.info("Storing results in database.")
+            # Store the Twitter user's screen name, JSON response of the Tweet and Botometer API results
+            self.cur.execute(
+                "INSERT INTO data values (?, ?, ?)",
+                [status.user.screen_name, json.dumps(status._json), json.dumps(result)],
+            )
+            self.con.commit()
+        except botometer.NoTimelineError as err:
+            logging.warning(f"Twitter user: {status.user.screen_name} has no timeline. Continuing...")
 
 
 if __name__ == "__main__":

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -54,9 +54,13 @@ class CustomStreamListener(tweepy.StreamListener):
         Returns:
             bool: `False` to disconnect from the Twitter stream.
         """
+        logging.error(f"Error code: {status_code} received from the Twitter stream.")
         if status_code == 420:
+            logging.error(f"We're being rate limited! Disconnecting.")
             # We're being rate limited by the Twitter API so disconnect
             return False
+        # Reconnect to the Twitter stream
+        return True
 
     def on_status(self, status: tweepy.Status):
         """Called when a new status (Tweet) is received from the Twitter stream.

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -96,7 +96,7 @@ class CustomStreamListener(tweepy.StreamListener):
             )
         except tweepy.TweepError as err:
             logging.error(
-                f"Failed to query the Botometer API for Twitter user: {status.user.screen_name}\n{err}\nContinuing..."
+                f"Failed to query the Botometer API for Twitter user: {status.user.screen_name}\n{err}\nYour API quota may be exhausted if you see this message multiple times."
             )
 
 

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -82,7 +82,7 @@ class CustomStreamListener(tweepy.StreamListener):
                 [status.user.screen_name, json.dumps(status._json), json.dumps(result)],
             )
             self.con.commit()
-        except botometer.NoTimelineError as err:
+        except botometer.NoTimelineError:
             logging.warning(f"Twitter user: {status.user.screen_name} has no timeline. Continuing...")
 
 

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -83,8 +83,9 @@ class CustomStreamListener(tweepy.StreamListener):
             )
             self.con.commit()
         except botometer.NoTimelineError:
-            logging.warning(f"Twitter user: {status.user.screen_name} has no timeline. Continuing...")
-
+            logging.error(f"Twitter user: {status.user.screen_name} has no timeline. Continuing...")
+        except tweepy.TweepError as err:
+            logging.error(f"Failed to query the Botometer API for Twitter user: {status.user.screen_name}\n{err}\nContinuing...")
 
 if __name__ == "__main__":
     try:

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -102,7 +102,7 @@ class CustomStreamListener(tweepy.StreamListener):
 
 if __name__ == "__main__":
     try:
-        VERSION = "0.1.0"
+        VERSION = "0.1.1"
         parser = argparse.ArgumentParser(
             description="An application to watch the Twitter stream and send accounts to the Botometer API for analysis. The results are stored in a SQLite database."
         )

--- a/twitter-stream-bot-data-gatherer/main.py
+++ b/twitter-stream-bot-data-gatherer/main.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
                 # Most likely our client is falling behind
                 # Reconnect to the Twitter stream and continue tracking
                 logging.error(
-                    f"An error occurred whilst tracking the Twitter stream. Reconnecting and continuing..."
+                    f"An error occurred whilst tracking the Twitter stream:\n{err}\nReconnecting and continuing..."
                 )
                 continue
     except KeyboardInterrupt:


### PR DESCRIPTION
# 0.1.1

## Fixes
* Handle `ProtocolError` and `IncompleteRead`. Reconnect to the Twitter stream when raised.
* Return `True` in `on_error` to reconnect to the Twitter stream if `status_code` is not `420`.
* Handle `NoTimelineError` and `TweepError` when retrieving bot-like scores from the Botometer API.